### PR TITLE
check domain name against db-filter case insensitive

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1504,7 +1504,7 @@ def db_filter(dbs, httprequest=None):
     if odoo.tools.config['dbfilter']:
         d, h = re.escape(d), re.escape(h)
         r = odoo.tools.config['dbfilter'].replace('%h', h).replace('%d', d)
-        dbs = [i for i in dbs if re.match(r, i)]
+        dbs = [i for i in dbs if re.match(r, i, flags=re.IGNORECASE)]
     elif odoo.tools.config['db_name']:
         # In case --db-filter is not provided and --database is passed, Odoo will
         # use the value of --database as a comma seperated list of exposed databases.


### PR DESCRIPTION
This is a fix for
db-filter should match the domain case insensitive #77540

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
